### PR TITLE
Add life insurance calculator and tests

### DIFF
--- a/life_insurance.py
+++ b/life_insurance.py
@@ -1,11 +1,53 @@
-def life_insurance_calculator(age: int, income: int, debts: int, dependents: int) -> int:
-    """Return recommended life insurance coverage.
+"""Utilities for estimating life insurance coverage needs."""
 
-    The calculation uses a simple rule of thumb: ten times income plus
-    outstanding debts plus $100,000 for each dependent.
-    Inputs must be non-negative or ``ValueError`` is raised.
+from __future__ import annotations
+
+from numbers import Integral
+
+DEPENDENT_SUPPORT_AMOUNT = 100_000
+FINAL_EXPENSE_BUFFER = 15_000
+
+
+def _validate_non_negative_int(name: str, value: int) -> int:
+    """Return ``value`` when it is a non-negative integer.
+
+    ``bool`` values are rejected even though ``bool`` is a subclass of ``int``.
     """
-    values = [age, income, debts, dependents]
-    if any(v < 0 for v in values):
-        raise ValueError("All inputs must be non-negative")
-    return income * 10 + debts + dependents * 100_000
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise TypeError(f"{name} must be an integer")
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative")
+    return int(value)
+
+
+def _income_multiplier(age: int) -> int:
+    """Return the earnings replacement multiplier for the given age."""
+    if age < 30:
+        return 12
+    if age < 45:
+        return 10
+    if age < 60:
+        return 7
+    return 5
+
+
+def life_insurance_calculator(age: int, income: int, debts: int, dependents: int) -> int:
+    """Estimate recommended life insurance coverage.
+
+    The estimate combines:
+    - age-based income replacement,
+    - outstanding debts,
+    - support for each dependent, and
+    - a small final-expense buffer.
+    """
+    age = _validate_non_negative_int("age", age)
+    income = _validate_non_negative_int("income", income)
+    debts = _validate_non_negative_int("debts", debts)
+    dependents = _validate_non_negative_int("dependents", dependents)
+
+    return (
+        income * _income_multiplier(age)
+        + debts
+        + dependents * DEPENDENT_SUPPORT_AMOUNT
+        + FINAL_EXPENSE_BUFFER
+    )

--- a/life_insurance.py
+++ b/life_insurance.py
@@ -1,0 +1,11 @@
+def life_insurance_calculator(age: int, income: int, debts: int, dependents: int) -> int:
+    """Return recommended life insurance coverage.
+
+    The calculation uses a simple rule of thumb: ten times income plus
+    outstanding debts plus $100,000 for each dependent.
+    Inputs must be non-negative or ``ValueError`` is raised.
+    """
+    values = [age, income, debts, dependents]
+    if any(v < 0 for v in values):
+        raise ValueError("All inputs must be non-negative")
+    return income * 10 + debts + dependents * 100_000

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_life.py
+++ b/tests/test_life.py
@@ -1,24 +1,70 @@
-import sys
-import os
-
-# Ensure project root is on path for local imports
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 import pytest
 
-from life_insurance import life_insurance_calculator
+from life_insurance import (
+    DEPENDENT_SUPPORT_AMOUNT,
+    FINAL_EXPENSE_BUFFER,
+    life_insurance_calculator,
+)
 
 
-def test_calculator_typical_case():
-    result = life_insurance_calculator(30, 50000, 20000, 2)
-    assert result == 50000 * 10 + 20000 + 2 * 100000
+@pytest.mark.parametrize(
+    ("age", "income", "debts", "dependents", "expected"),
+    [
+        (
+            25,
+            50_000,
+            20_000,
+            2,
+            50_000 * 12 + 20_000 + 2 * DEPENDENT_SUPPORT_AMOUNT + FINAL_EXPENSE_BUFFER,
+        ),
+        (
+            40,
+            80_000,
+            0,
+            0,
+            80_000 * 10 + FINAL_EXPENSE_BUFFER,
+        ),
+        (
+            55,
+            90_000,
+            15_000,
+            1,
+            90_000 * 7 + 15_000 + DEPENDENT_SUPPORT_AMOUNT + FINAL_EXPENSE_BUFFER,
+        ),
+        (
+            65,
+            60_000,
+            10_000,
+            0,
+            60_000 * 5 + 10_000 + FINAL_EXPENSE_BUFFER,
+        ),
+    ],
+)
+def test_calculator_recommends_coverage_by_age_band(age, income, debts, dependents, expected):
+    assert life_insurance_calculator(age, income, debts, dependents) == expected
 
 
-def test_calculator_zero_dependents_and_debts():
-    result = life_insurance_calculator(40, 80000, 0, 0)
-    assert result == 80000 * 10
+@pytest.mark.parametrize("field", ["age", "income", "debts", "dependents"])
+def test_calculator_rejects_negative_values(field):
+    values = {"age": 35, "income": 70_000, "debts": 5_000, "dependents": 1}
+    values[field] = -1
+
+    with pytest.raises(ValueError, match=field):
+        life_insurance_calculator(**values)
 
 
-def test_calculator_negative_input():
-    with pytest.raises(ValueError):
-        life_insurance_calculator(30, -50000, 1000, 1)
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("age", 30.5),
+        ("income", "50000"),
+        ("debts", None),
+        ("dependents", True),
+    ],
+)
+def test_calculator_rejects_non_integer_values(field, value):
+    values = {"age": 35, "income": 70_000, "debts": 5_000, "dependents": 1}
+    values[field] = value
+
+    with pytest.raises(TypeError, match=field):
+        life_insurance_calculator(**values)

--- a/tests/test_life.py
+++ b/tests/test_life.py
@@ -1,0 +1,24 @@
+import sys
+import os
+
+# Ensure project root is on path for local imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+
+from life_insurance import life_insurance_calculator
+
+
+def test_calculator_typical_case():
+    result = life_insurance_calculator(30, 50000, 20000, 2)
+    assert result == 50000 * 10 + 20000 + 2 * 100000
+
+
+def test_calculator_zero_dependents_and_debts():
+    result = life_insurance_calculator(40, 80000, 0, 0)
+    assert result == 80000 * 10
+
+
+def test_calculator_negative_input():
+    with pytest.raises(ValueError):
+        life_insurance_calculator(30, -50000, 1000, 1)


### PR DESCRIPTION
## Summary
- implement a simple `life_insurance_calculator` function
- add unit tests in `tests/test_life.py`

## Testing
- `pytest -q`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6862f85514a08320a195bbc958d56150)